### PR TITLE
Fix sub-group column resize bug

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -2,10 +2,36 @@
 
 <table id="table" mat-table [dataSource]="dataSource" style="width: 100%;">
 
+  <!-- Fix resize columngs -->
   <ng-container matColumnDef="first">
-    <th mat-header-cell *matHeaderCellDef colspan="2" style="text-align: center;"> first Sub col </th>
+    <th mat-header-cell *matHeaderCellDef ></th>
   </ng-container>
 
+  <ng-container matColumnDef="second">
+    <th mat-header-cell *matHeaderCellDef ></th>
+  </ng-container>
+
+  <ng-container matColumnDef="third">
+    <th mat-header-cell *matHeaderCellDef ></th>
+  </ng-container>
+
+  <ng-container matColumnDef="fourth">
+    <th mat-header-cell *matHeaderCellDef ></th>
+  </ng-container>
+  
+  <!-- Group columns -->
+    <!-- group 1 -->
+  <ng-container matColumnDef="Group-1">
+    <th mat-header-cell *matHeaderCellDef style="text-align: center;" colspan="2">Group 1</th>
+  </ng-container>
+
+  <!-- group 2 -->
+  <ng-container matColumnDef="Group-2">
+    <th mat-header-cell *matHeaderCellDef style="text-align: center;" colspan="2">Group 2</th>
+  </ng-container>
+<!-- End -->
+
+  <!-- Sub column of group 1 -->
   <ng-container matColumnDef="position">
     <th mat-header-cell *matHeaderCellDef> No. </th>
     <td mat-cell *matCellDef="let element"> {{element.position}} </td>
@@ -15,21 +41,21 @@
     <th mat-header-cell *matHeaderCellDef> Name </th>
     <td mat-cell *matCellDef="let element"> {{element.name}} </td>
   </ng-container>
+<!-- End -->
 
-  <ng-container matColumnDef="second">
-    <th mat-header-cell *matHeaderCellDef colspan="2" style="text-align: center;"> second Sub col </th>
-  </ng-container>
+<!-- Sub column of group 2 -->
+<ng-container matColumnDef="weight">
+  <th mat-header-cell *matHeaderCellDef> Weight </th>
+  <td mat-cell *matCellDef="let element"> {{element.weight}} </td>
+</ng-container>
 
-  <ng-container matColumnDef="weight">
-    <th mat-header-cell *matHeaderCellDef> Weight </th>
-    <td mat-cell *matCellDef="let element"> {{element.weight}} </td>
-  </ng-container>
+<ng-container matColumnDef="symbol">
+  <th mat-header-cell *matHeaderCellDef> Symbol </th>
+  <td mat-cell *matCellDef="let element"> {{element.symbol}} </td>
+</ng-container>
+<!-- End -->
 
-  <ng-container matColumnDef="symbol">
-    <th mat-header-cell *matHeaderCellDef> Symbol </th>
-    <td mat-cell *matCellDef="let element"> {{element.symbol}} </td>
-  </ng-container>
-
+  <tr mat-header-row *matHeaderRowDef="fixResizeableColumns"></tr>
   <tr mat-header-row *matHeaderRowDef="displayedSubColumns"></tr>
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
   <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,3 +1,8 @@
 #table th{
     border: 1px solid black;
 }
+
+#table tr:first-child{
+    visibility: hidden;
+    height: 0 !important;
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -32,10 +32,12 @@ export class AppComponent {
   title = 'subHeader';
   displayedColumns: string[];
   displayedSubColumns: string[];
+  fixResizeableColumns: string[];
   dataSource:any;
   constructor(){
     this.displayedColumns = ['position', 'name', 'weight', 'symbol'];
-    this.displayedSubColumns = ['first', 'second'];
+    this.fixResizeableColumns = ['first', 'second', 'third', 'fourth'];
+    this.displayedSubColumns = ['Group-1', 'Group-2'];
     this.dataSource = ELEMENT_DATA;
   }
 
@@ -43,7 +45,8 @@ export class AppComponent {
     setTimeout(function(){
       $('#table').colResizable({         //colResizable - jquery pluging to resize.
         resizeMode:'overflow',
-        minWidth:50
+        minWidth:50,
+        liveShow: true
       })
     },100);
   }


### PR DESCRIPTION
Changes:
1) Update the CSS for the first row of the table
2) Add a dummy first column to fix the column resize bug. We have to add this first dummy column because in the documentation of colResizable it is mentioned that it uses header row to setup resizable feature.